### PR TITLE
fix(platform): set kube proxy metrics addr to 0.0.0.0

### DIFF
--- a/pkg/platform/provider/baremetal/cluster/kubeadm.go
+++ b/pkg/platform/provider/baremetal/cluster/kubeadm.go
@@ -168,6 +168,7 @@ func (p *Provider) getKubeProxyConfiguration(c *v1.Cluster) *kubeproxyv1alpha1.K
 		config.Mode = "ipvs"
 		config.ClusterCIDR = c.Spec.ClusterCIDR
 	}
+	config.MetricsBindAddress = "0.0.0.0"
 
 	return config
 }


### PR DESCRIPTION
 set kube proxy metrics addr to 0.0.0.0

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind feature

**What this PR does / why we need it**:
The default metric address is 127.0.0.1. We need to change it to the real address every time when we make the cluster.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

